### PR TITLE
Upgrade dependencies, update CI/CD workflows, bump to 0.2.0

### DIFF
--- a/.github/workflows/rust-cd.yml
+++ b/.github/workflows/rust-cd.yml
@@ -9,58 +9,32 @@ jobs:
   publish-binary:
     runs-on: ${{ matrix.platform.os }}
     strategy:
+      fail-fast: false
       matrix:
-        rust: [ stable ]
         platform:
           - os: macos-latest
             os-name: macos
             target: x86_64-apple-darwin
             architecture: x86_64
             binary-postfix: ""
-            use-cross: false
           - os: ubuntu-latest
             os-name: linux
             target: x86_64-unknown-linux-gnu
             architecture: x86_64
             binary-postfix: ""
-            use-cross: false
           - os: windows-latest
             os-name: windows
             target: x86_64-pc-windows-msvc
             architecture: x86_64
             binary-postfix: ".exe"
-            use-cross: false
-          - os: ubuntu-latest
-            os-name: linux
-            target: aarch64-unknown-linux-gnu
-            architecture: arm64
-            binary-postfix: ""
-            use-cross: true
-          - os: ubuntu-latest
-            os-name: linux
-            target: i686-unknown-linux-gnu
-            architecture: i686
-            binary-postfix: ""
-            use-cross: true
 
     steps:
-      - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: ${{ matrix.rust }}
-          profile: minimal
-          override: true
-
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Cargo build
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          use-cross: ${{ matrix.platform.use-cross }}
-          toolchain: ${{ matrix.rust }}
-          args: --release --target ${{ matrix.platform.target }}
+        uses: dtolnay/rust-toolchain@stable
+        run: cargo build -v --release --target ${{ matrix.platform.target }}
 
       - name: Package final binary
         shell: bash

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -15,27 +15,23 @@ env:
 jobs:
   build-crate:
     name: Build and test crate/docs
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}-latest
     strategy:
+      fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu, windows, macos]
         toolchain: [nightly, beta, stable]
-        include:
-          - os: macos-latest
-            toolchain: stable
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: ${{ matrix.toolchain }}
           components: rust-docs
-          override: true
       - name: Build library
         run: cargo build -v --lib --no-default-features
       - name: Build binary
         run: cargo build -v --bins
-      - name: Test library
+      - name: Library tests
         run: cargo test --no-default-features --lib
       - name: Doc tests
         run: cargo test --doc --no-default-features
@@ -47,13 +43,10 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
-          toolchain: stable
           components: clippy, rustfmt
-          override: true
       - name: clippy
         run: cargo clippy
         continue-on-error: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,6 @@ Improved SLIC calculation speed by ~15-20% after refactoring calculation loop.
 ## Version 0.1.0 - 2022-04
 - Initial Commit
 
-[documentation]: https://docs.rs/simple_clustering
-[1]: https://github.com/okaneco/simple_clustering/pull/1
 [3]: https://github.com/okaneco/simple_clustering/pull/3
+[1]: https://github.com/okaneco/simple_clustering/pull/1
+[documentation]: https://docs.rs/simple_clustering

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # `simple_clustering` changelog
 
+## Version 0.2.0 - 2023-07
+Updated the color-handling crate, `palette`, from `0.6` to `0.7`. Users will
+need to change from using `palette::Pixel::from_raw_slice` to
+`palette::cast::from_component_slice` for preparing the input image buffer.
+
+Consult the [documentation] or `lib.rs` file for examples.
+
+[#3][3] - Upgrade dependencies, update CI/CD workflows, bump to 0.2.0
+
 ## Version 0.1.1 - 2023-01
 Improved SLIC calculation speed by ~15-20% after refactoring calculation loop.
 
@@ -8,4 +17,6 @@ Improved SLIC calculation speed by ~15-20% after refactoring calculation loop.
 ## Version 0.1.0 - 2022-04
 - Initial Commit
 
+[documentation]: https://docs.rs/simple_clustering
 [1]: https://github.com/okaneco/simple_clustering/pull/1
+[3]: https://github.com/okaneco/simple_clustering/pull/3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,9 +31,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bytemuck"
-version = "1.12.3"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aaa3a8d9a1ca92e282c96a32d6511b695d7d994d1d102ba85d279f9b2756947f"
+checksum = "17febce684fd15d89027105661fec94afb475cb995fbc59d2865198446ba2eea"
 
 [[package]]
 name = "byteorder"
@@ -49,9 +49,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "3.2.23"
+version = "3.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
+checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
 dependencies = [
  "bitflags",
  "clap_derive",
@@ -64,15 +64,15 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.2.18"
+version = "3.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
+checksum = "ae6371b8bdc8b7d3959e9cf7b22d4435ef3e79e138688421ec654acf8c81b008"
 dependencies = [
  "heck",
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -100,19 +100,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "find-crate"
-version = "0.6.3"
+name = "fast-srgb8"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59a98bbaacea1c0eb6a0876280051b892eb73594fd90cf3b20e9c817029c57d2"
+checksum = "dd2e7510819d6fbf51a5545c8f922716ecfb14df168a3242f7d33e0239efe6a1"
+
+[[package]]
+name = "fdeflate"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d329bdeac514ee06249dabc27877490f17f5d371ec693360768b838e19f3ae10"
 dependencies = [
- "toml",
+ "simd-adler32",
 ]
 
 [[package]]
 name = "flate2"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8a2db397cb1c8772f31494cb8917e48cd1e64f0fa7efac59fbd741a0a8ce841"
+checksum = "3b9429470923de8e8cbd4d2dc513535400b4b3fef0319fb5c4e1f520a7bef743"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -135,15 +141,15 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "heck"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "image"
-version = "0.24.5"
+version = "0.24.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69b7ea949b537b0fd0af141fff8c77690f2ce96f4f41f042ccb6c69c6c965945"
+checksum = "527909aa81e20ac3a44803521443a765550f09b5130c2c2fa1ea59c2f8f50a3a"
 dependencies = [
  "bytemuck",
  "byteorder",
@@ -156,9 +162,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.9.2"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -172,11 +178,12 @@ checksum = "bc0000e42512c92e31c2252315bda326620a4e034105e900c98ec492fa077b3e"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.6.2"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
+checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
 dependencies = [
  "adler",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -202,56 +209,56 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+checksum = "f30b0abd723be7e2ffca1272140fac1a2f084c77ec3e123c192b66af1ee9e6c2"
 dependencies = [
  "autocfg",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.17.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
+checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "os_str_bytes"
-version = "6.4.1"
+version = "6.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
+checksum = "4d5d9eb14b174ee9aa2ef96dc2b94637a2d4b6e7cb873c7e171f0c20c6cf3eac"
 
 [[package]]
 name = "palette"
-version = "0.6.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f9cd68f7112581033f157e56c77ac4a5538ec5836a2e39284e65bd7d7275e49"
+checksum = "e1641aee47803391405d0a1250e837d2336fdddd18b27f3ddb8c1d80ce8d7f43"
 dependencies = [
  "approx",
- "num-traits",
+ "fast-srgb8",
  "palette_derive",
 ]
 
 [[package]]
 name = "palette_derive"
-version = "0.6.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05eedf46a8e7c27f74af0c9cfcdb004ceca158cb1b918c6f68f8d7a549b3e427"
+checksum = "3c02bfa6b3ba8af5434fa0531bf5701f750d983d4260acd6867faca51cdc4484"
 dependencies = [
- "find-crate",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.27",
 ]
 
 [[package]]
 name = "png"
-version = "0.17.7"
+version = "0.17.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d708eaf860a19b19ce538740d2b4bdeeb8337fa53f7738455e706623ad5c638"
+checksum = "59871cc5b6cce7eaccca5a802b4173377a1c2ba90654246789a8fa2334426d11"
 dependencies = [
  "bitflags",
  "crc32fast",
+ "fdeflate",
  "flate2",
  "miniz_oxide",
 ]
@@ -265,7 +272,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "version_check",
 ]
 
@@ -282,31 +289,31 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.49"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57a8eca9f9c4ffde41714334dee777596264c7825420f521abc92b5b5deb63a5"
+checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.23"
+version = "1.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
+checksum = "5fe8a65d69dd0808184ebb5f836ab526bb259db23c657efa38711b1072ee47f0"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
-name = "serde"
-version = "1.0.152"
+name = "simd-adler32"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
+checksum = "238abfbb77c1915110ad968465608b68e869e0772622c9656714e73e5a1a522f"
 
 [[package]]
 name = "simple_clustering"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "clap",
  "fxhash",
@@ -323,9 +330,20 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.107"
+version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b60f673f44a8255b9c8c657daf66a596d435f2da81a555b06dc644d080ba45e0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -339,19 +357,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
-name = "toml"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1333c76748e868a4d9d1017b5ab53171dfd095f70c712fdb4653a406547f598f"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "unicode-ident"
-version = "1.0.6"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
+checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ default-features = false
 features = ["std"]
 
 [profile.release]
+codegen-units = 1
 strip = true
 
 [package.metadata.docs.rs]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simple_clustering"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 exclude = ["gfx", ".github"]
 description = "Implementations of image clustering and segmentation algorithms such as SLIC and SNIC."
@@ -33,7 +33,7 @@ version = "0.2.1"
 default-features = false
 
 [dependencies.image]
-version = "0.24.2"
+version = "0.24.6"
 default-features = false
 features = ["jpeg", "png"]
 optional = true
@@ -41,9 +41,10 @@ optional = true
 [dependencies.num-traits]
 version = "0.2.15"
 default-features = false
+features = ["std"]
 
 [dependencies.palette]
-version = "0.6"
+version = "0.7.2"
 default-features = false
 features = ["std"]
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ can be found at https://github.com/okaneco/simple_clustering/releases.
 
 ```toml
 [dependencies.simple_clustering]
-version = "0.1"
+version = "0.2"
 default-features = false
 ```
 

--- a/src/bin/simple_clustering/main.rs
+++ b/src/bin/simple_clustering/main.rs
@@ -6,7 +6,7 @@ use crate::utils::{generate_filename, save_image, Algorithm};
 
 use clap::Parser;
 
-use palette::{FromColor, Lab, Pixel, Srgb};
+use palette::{cast, FromColor, Lab, Srgb};
 use simple_clustering::image::{count_colors, mean_colors, segment_contours};
 use std::fmt::Write;
 use std::str::FromStr;
@@ -29,7 +29,7 @@ fn try_main() -> Result<(), Box<dyn std::error::Error>> {
 
     let input_image = image::open(opt.input)?.into_rgb8();
     let (width, height) = input_image.dimensions();
-    let input_buffer = Srgb::from_raw_slice(input_image.as_raw());
+    let input_buffer = cast::from_component_slice::<Srgb<u8>>(input_image.as_raw());
     let mut input_lab: Vec<Lab<_, f64>> = Vec::new();
     input_lab.try_reserve_exact(input_buffer.len())?;
     input_lab.extend(
@@ -78,9 +78,9 @@ fn try_main() -> Result<(), Box<dyn std::error::Error>> {
         }
     };
 
-    let segment_color = *Srgb::from_str(opt.segment_color.as_str())
+    let segment_color = Srgb::from_str(opt.segment_color.as_str())
         .or(Err("Segment color is invalid hex"))?
-        .as_raw();
+        .into();
 
     if !opt.no_mean {
         let num_segments = mean_colors(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,14 +17,14 @@
 //! ### SNIC
 //!
 //! ```
-//! use palette::{FromColor, Lab, Pixel, Srgb};
+//! use palette::{cast, FromColor, Lab, Srgb};
 //! use simple_clustering::snic;
 //!
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! # let (width, height) = (1, 3);
 //! # let image = [0u8, 0, 0, 127, 127, 127, 255, 255, 255];
 //! # let (k, m) = (1, 10);
-//! let lab_buffer: Vec<Lab<_, f64>> = Srgb::from_raw_slice(&image)
+//! let lab_buffer: Vec<Lab<_, f64>> = cast::from_component_slice::<Srgb<u8>>(&image)
 //!     .iter()
 //!     .map(|&c| Lab::from_color(c.into_format()))
 //!     .collect();
@@ -37,14 +37,14 @@
 //! ### SLIC
 //!
 //! ```
-//! use palette::{FromColor, Lab, Pixel, Srgb};
+//! use palette::{cast, FromColor, Lab, Srgb};
 //! use simple_clustering::slic;
 //!
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! # let (width, height) = (1, 3);
 //! # let image = [0u8, 0, 0, 127, 127, 127, 255, 255, 255];
 //! # let (k, m) = (1, 10);
-//! let lab_buffer: Vec<Lab<_, f64>> = Srgb::from_raw_slice(&image)
+//! let lab_buffer: Vec<Lab<_, f64>> = cast::from_component_slice::<Srgb<u8>>(&image)
 //!     .iter()
 //!     .map(|&c| Lab::from_color(c.into_format()))
 //!     .collect();
@@ -60,7 +60,7 @@
 //! around those segments.
 //!
 //! ```
-//! # use palette::{FromColor, Lab, Pixel, Srgb};
+//! # use palette::{cast, FromColor, Lab, Srgb};
 //! # use simple_clustering::snic;
 //! use simple_clustering::image::{mean_colors, segment_contours};
 //!
@@ -68,7 +68,7 @@
 //! # let (width, height) = (1, 3);
 //! # let image = [0u8, 0, 0, 127, 127, 127, 255, 255, 255];
 //! # let (k, m) = (1, 10);
-//! # let lab_buffer: Vec<Lab<_, f64>> = Srgb::from_raw_slice(&image)
+//! # let lab_buffer: Vec<Lab<_, f64>> = cast::from_component_slice::<Srgb<u8>>(&image)
 //! #    .iter()
 //! #    .map(|&c| Lab::from_color(c.into_format()))
 //! #    .collect();
@@ -98,7 +98,7 @@
 )]
 
 use num_traits::{Float, One, Unsigned, Zero};
-use palette::{white_point::WhitePoint, FloatComponent, Lab};
+use palette::Lab;
 use std::ops::{Add, Div, Rem};
 
 pub mod error;
@@ -124,21 +124,26 @@ fn calculate_grid_interval(width: u32, height: u32, superpixels: u32) -> f64 {
 #[inline]
 fn distance_lab<Wp, T>(lhs: Lab<Wp, T>, rhs: Lab<Wp, T>) -> T
 where
-    Wp: WhitePoint,
-    T: FloatComponent,
+    T: Float,
 {
     (rhs.l - lhs.l).powi(2) + (rhs.a - lhs.a).powi(2) + (rhs.b - lhs.b).powi(2)
 }
 
 /// Calculate the distance between two two-dimensional points.
 #[inline]
-fn distance_xy<T: Float>(lhs: (T, T), rhs: (T, T)) -> T {
+fn distance_xy<T>(lhs: (T, T), rhs: (T, T)) -> T
+where
+    T: Float,
+{
     (rhs.0 - lhs.0).powi(2) + (rhs.1 - lhs.1).powi(2)
 }
 
 /// Calculate the `s` distance.
 #[inline]
-fn distance_s<T: Float>(m_div_s: T, d_lab: T, d_xy: T) -> T {
+fn distance_s<T>(m_div_s: T, d_lab: T, d_xy: T) -> T
+where
+    T: core::ops::Add<Output = T> + core::ops::Mul<Output = T>,
+{
     d_lab + m_div_s * d_xy
 }
 

--- a/src/seed.rs
+++ b/src/seed.rs
@@ -2,8 +2,8 @@
 use crate::error::{ScError, SeedErrorKind};
 use crate::{distance_lab, div_ceil, get_in_bounds, Superpixel};
 
-use num_traits::ToPrimitive;
-use palette::{white_point::WhitePoint, FloatComponent, Lab};
+use num_traits::{Float, FromPrimitive, ToPrimitive};
+use palette::Lab;
 
 /// Initialize the superpixel seed centers.
 ///
@@ -103,10 +103,10 @@ pub fn perturb<Wp, T>(
     image: &[Lab<Wp, T>],
 ) -> Result<(), ScError>
 where
-    Wp: WhitePoint,
-    T: FloatComponent,
+    T: Float + FromPrimitive,
+    Lab<Wp, T>: Default,
 {
-    let mut min = T::infinity();
+    let mut min = T::from_f64(f64::INFINITY).unwrap();
     let default = Lab::<Wp, T>::default();
     let sp_x = i64::from(seed.x);
     let sp_y = i64::from(seed.y);

--- a/src/snic.rs
+++ b/src/snic.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 
 use num_traits::ToPrimitive;
-use palette::{white_point::D65, FromColor, Lab, Pixel, Srgb};
+use palette::{cast, FromColor, Lab, Srgb};
 
 /// Struct used for accumulating and calculating superpixel clusters in SNIC.
 #[derive(Debug, Clone, Copy)]
@@ -62,7 +62,7 @@ pub fn snic_from_bytes(
     {
         return Err(ScError::MismatchedSnicBuffer);
     }
-    let input_buffer = Srgb::from_raw_slice(image);
+    let input_buffer = cast::from_component_slice::<Srgb<u8>>(image);
     let mut input_lab: Vec<Lab<_, f64>> = Vec::new();
     input_lab.try_reserve_exact(input_buffer.len())?;
     input_lab.extend(
@@ -85,12 +85,12 @@ pub fn snic_from_bytes(
 /// *Achanta, R., & Süsstrunk, S. Superpixels and polygons using simple
 /// non-iterative clustering. Proceedings of the IEEE Conference on Computer Vision
 /// and Pattern Recognition, 2017.*
-pub fn snic(
+pub fn snic<Wp>(
     k: u32,
     m: u8,
     width: u32,
     height: u32,
-    image: &[Lab<D65, f64>],
+    image: &[Lab<Wp, f64>],
 ) -> Result<Vec<usize>, ScError> {
     let width_i = i64::from(width);
     let height_i = i64::from(height);
@@ -136,7 +136,7 @@ pub fn snic(
     labels.extend((0..image.len()).map(|_| 0_usize));
 
     // Leave the first entry vacant since label k starts at 1
-    let mut updates: Vec<SnicUpdate<Lab<D65, f64>>> = Vec::new();
+    let mut updates: Vec<SnicUpdate<Lab<Wp, f64>>> = Vec::new();
     updates.try_reserve_exact(clusters.len().saturating_add(1))?;
     updates.extend((0..=clusters.len()).map(|_| SnicUpdate::new()));
 


### PR DESCRIPTION
Upgrade to `image 0.24.6`
Upgrade to `palette 0.7.2`
- Remove `palette::Pixel`, replace with `palette::cast`
- Remove `palette::FloatComponent`, replace with `num_traits::Float`
- Fix assorted trait bounds cascading from `FloatComponent` deletion
- Fix doc tests

Set release profile to `codegen-units=1` for better performance
Fix clippy lints
Annotate loop with `clippy::cast_precision_loss` attribute in slic
Migrate away from unmaintained `actions-rs` GH actions
