### PR TITLE
Update GH Action CD workflow

### DIFF
--- a/.github/workflows/rust-cd.yml
+++ b/.github/workflows/rust-cd.yml
@@ -29,12 +29,9 @@ jobs:
             binary-postfix: ".exe"
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-
-      - name: Cargo build
-        uses: dtolnay/rust-toolchain@stable
-        run: cargo build -v --release --target ${{ matrix.platform.target }}
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo build -v --release --target ${{ matrix.platform.target }}
 
       - name: Package final binary
         shell: bash


### PR DESCRIPTION
Fix error
> a step cannot have both the `uses` and `run` keys